### PR TITLE
Fix bug in addition in murmur3a hash.

### DIFF
--- a/murmurhash3_gc.js
+++ b/murmurhash3_gc.js
@@ -29,13 +29,13 @@ function murmurhash3_32_gc(key, seed) {
 	  	  ((key.charCodeAt(++i) & 0xff) << 24);
 		++i;
 		
-		k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16));
+		k1 = ((((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16))) & 0xffffffff;
 		k1 = (k1 << 15) | (k1 >>> 17);
-		k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16));
+		k1 = ((((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16))) & 0xffffffff;
 
 		h1 ^= k1;
         h1 = (h1 << 13) | (h1 >>> 19);
-		h1b = (((h1 & 0xffff) * 5) + ((((h1 >>> 16) * 5) & 0xffff) << 16));
+		h1b = ((((h1 & 0xffff) * 5) + ((((h1 >>> 16) * 5) & 0xffff) << 16))) & 0xffffffff;
 		h1 = (((h1b & 0xffff) + 0x6b64) + ((((h1b >>> 16) + 0xe654) & 0xffff) << 16));
 	}
 	
@@ -46,18 +46,18 @@ function murmurhash3_32_gc(key, seed) {
 		case 2: k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
 		case 1: k1 ^= (key.charCodeAt(i) & 0xff);
 		
-		k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16));
+		k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16)) & 0xffffffff;
 		k1 = (k1 << 16) | (k1 >>> 16);
-		k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16));
+		k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16)) & 0xffffffff;
 		h1 ^= k1;
 	}
 	
 	h1 ^= key.length;
 
 	h1 ^= h1 >>> 16;
-	h1 = (((h1 & 0xffff) * 0xca6b) + ((((h1 >>> 16) * 0x85eb) & 0xffff) << 16));
+	h1 = (((h1 & 0xffff) * 0x85ebca6b) + ((((h1 >>> 16) * 0x85ebca6b) & 0xffff) << 16)) & 0xffffffff;
 	h1 ^= h1 >>> 13;
-	h1 = (((h1 & 0xffff) * 0xae35) + ((((h1 >>> 16) * 0xc2b2) & 0xffff) << 16));
+	h1 = ((((h1 & 0xffff) * 0xc2b2ae35) + ((((h1 >>> 16) * 0xc2b2ae35) & 0xffff) << 16))) & 0xffffffff;
 	h1 ^= h1 >>> 16;
 
 	return h1 >>> 0;

--- a/murmurhash3_gc.js
+++ b/murmurhash3_gc.js
@@ -14,11 +14,11 @@
 function murmurhash3_32_gc(key, seed) {
 	var remainder, bytes, h1, h1b, c1, c1b, c2, c2b, k1, i;
 	
-	remainder = key.length % 4;
+	remainder = key.length & 3; // key.length % 4
 	bytes = key.length - remainder;
-	h1 = 0x971e137b ^ seed;
-	c1 = 0x95543787;
-	c2 = 0x2ad7eb25;
+	h1 = seed;
+	c1 = 0xcc9e2d51;
+	c2 = 0x1b873593;
 	i = 0;
 	
 	while (i < bytes) {
@@ -30,17 +30,13 @@ function murmurhash3_32_gc(key, seed) {
 		++i;
 		
 		k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16));
-		k1 = (k1 << 11) | (k1 >>> 21);
+		k1 = (k1 << 15) | (k1 >>> 17);
 		k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16));
+
 		h1 ^= k1;
-		
-		h1b = (((h1 & 0xffff) * 3) + ((((h1 >>> 16) * 3) & 0xffff) << 16));
-		h1 = (((h1b & 0xffff) + 0xe729) + ((((h1b >>> 16) + 0x52dc) & 0xffff) << 16));
-	
-		c1b = (((c1 & 0xffff) * 5) + ((((c1 >>> 16) * 5) & 0xffff) << 16)); 
-		c1 = (((c1b & 0xffff) + 0x159c) + ((((c1b >>> 16) + 0x7b7d) & 0xffff) << 16));
-		c2b = (((c2 & 0xffff) * 5) + ((((c2 >>> 16) * 5) & 0xffff) << 16)); 
-		c2 = (((c2b & 0xffff) + 0x6396) + ((((c2b >>> 16) + 0x6bce) & 0xffff) << 16));
+        h1 = (h1 << 13) | (h1 >>> 19);
+		h1b = (((h1 & 0xffff) * 5) + ((((h1 >>> 16) * 5) & 0xffff) << 16));
+		h1 = (((h1b & 0xffff) + 0x6b64) + ((((h1b >>> 16) + 0xe654) & 0xffff) << 16));
 	}
 	
 	k1 = 0;
@@ -51,12 +47,9 @@ function murmurhash3_32_gc(key, seed) {
 		case 1: k1 ^= (key.charCodeAt(i) & 0xff);
 		
 		k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16));
-		k1 = (k1 << 11) | (k1 >>> 21);
+		k1 = (k1 << 16) | (k1 >>> 26);
 		k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16));
 		h1 ^= k1;
-		
-		h1b = (((h1 & 0xffff) * 3) + ((((h1 >>> 16) * 3) & 0xffff) << 16));
-		h1 = (((h1b & 0xffff) + 0xe729) + ((((h1b >>> 16) + 0x52dc) & 0xffff) << 16));
 	}
 	
 	h1 ^= key.length;

--- a/murmurhash3_gc.js
+++ b/murmurhash3_gc.js
@@ -35,12 +35,12 @@ function murmurhash3_32_gc(key, seed) {
 		h1 ^= k1;
 		
 		h1b = (((h1 & 0xffff) * 3) + ((((h1 >>> 16) * 3) & 0xffff) << 16));
-		h1 = (((h1b & 0xffff) + 0x52dce729) + ((((h1b >>> 16) + 0x52dce729) & 0xffff) << 16));
+		h1 = (((h1b & 0xffff) + 0xe729) + ((((h1b >>> 16) + 0x52dc) & 0xffff) << 16));
 	
 		c1b = (((c1 & 0xffff) * 5) + ((((c1 >>> 16) * 5) & 0xffff) << 16)); 
-		c1 = (((c1b & 0xffff) + 0x7b7d159c) + ((((c1b >>> 16) + 0x7b7d159c) & 0xffff) << 16));
+		c1 = (((c1b & 0xffff) + 0x159c) + ((((c1b >>> 16) + 0x7b7d) & 0xffff) << 16));
 		c2b = (((c2 & 0xffff) * 5) + ((((c2 >>> 16) * 5) & 0xffff) << 16)); 
-		c2 = (((c2b & 0xffff) + 0x6bce6396) + ((((c2b >>> 16) + 0x6bce6396) & 0xffff) << 16));
+		c2 = (((c2b & 0xffff) + 0x6396) + ((((c2b >>> 16) + 0x6bce) & 0xffff) << 16));
 	}
 	
 	k1 = 0;
@@ -56,15 +56,15 @@ function murmurhash3_32_gc(key, seed) {
 		h1 ^= k1;
 		
 		h1b = (((h1 & 0xffff) * 3) + ((((h1 >>> 16) * 3) & 0xffff) << 16));
-		h1 = (((h1b & 0xffff) + 0x52dce729) + ((((h1b >>> 16) + 0x52dce729) & 0xffff) << 16));
+		h1 = (((h1b & 0xffff) + 0xe729) + ((((h1b >>> 16) + 0x52dc) & 0xffff) << 16));
 	}
 	
 	h1 ^= key.length;
 
 	h1 ^= h1 >>> 16;
-	h1 = (((h1 & 0xffff) * 0x85ebca6b) + ((((h1 >>> 16) * 0x85ebca6b) & 0xffff) << 16));
+	h1 = (((h1 & 0xffff) * 0xca6b) + ((((h1 >>> 16) * 0x85eb) & 0xffff) << 16));
 	h1 ^= h1 >>> 13;
-	h1 = (((h1 & 0xffff) * 0xc2b2ae35) + ((((h1 >>> 16) * 0xc2b2ae35) & 0xffff) << 16));
+	h1 = (((h1 & 0xffff) * 0xae35) + ((((h1 >>> 16) * 0xc2b2) & 0xffff) << 16));
 	h1 ^= h1 >>> 16;
 
 	return h1 >>> 0;

--- a/murmurhash3_gc.js
+++ b/murmurhash3_gc.js
@@ -47,7 +47,7 @@ function murmurhash3_32_gc(key, seed) {
 		case 1: k1 ^= (key.charCodeAt(i) & 0xff);
 		
 		k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16));
-		k1 = (k1 << 16) | (k1 >>> 26);
+		k1 = (k1 << 16) | (k1 >>> 16);
 		k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16));
 		h1 ^= k1;
 	}

--- a/murmurhash3_gc.js
+++ b/murmurhash3_gc.js
@@ -1,5 +1,5 @@
 /**
- * JS Implementation of MurmurHash3 Beta (as of January 28, 2011)
+ * JS Implementation of MurmurHash3 (as of April 6, 2011)
  * 
  * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
  * @see http://github.com/garycourt/murmurhash-js


### PR DESCRIPTION
This splits the constants into 16-bit chunks while adding, as with the other addends.
