### PR TITLE
Adding case breaks for jshint

### DIFF
--- a/murmurhash2_gc.js
+++ b/murmurhash2_gc.js
@@ -1,11 +1,11 @@
 /**
  * JS Implementation of MurmurHash2
- * 
+ *
  * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
  * @see http://github.com/garycourt/murmurhash-js
  * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
  * @see http://sites.google.com/site/murmurhash/
- * 
+ *
  * @param {string} str ASCII only
  * @param {number} seed Positive integer only
  * @return {number} 32-bit positive integer hash
@@ -17,14 +17,14 @@ function murmurhash2_32_gc(str, seed) {
     h = seed ^ l,
     i = 0,
     k;
-  
+
   while (l >= 4) {
-  	k = 
+  	k =
   	  ((str.charCodeAt(i) & 0xff)) |
   	  ((str.charCodeAt(++i) & 0xff) << 8) |
   	  ((str.charCodeAt(++i) & 0xff) << 16) |
   	  ((str.charCodeAt(++i) & 0xff) << 24);
-    
+
     k = (((k & 0xffff) * 0x5bd1e995) + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16));
     k ^= k >>> 24;
     k = (((k & 0xffff) * 0x5bd1e995) + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16));
@@ -34,10 +34,10 @@ function murmurhash2_32_gc(str, seed) {
     l -= 4;
     ++i;
   }
-  
+
   switch (l) {
-  case 3: h ^= (str.charCodeAt(i + 2) & 0xff) << 16;
-  case 2: h ^= (str.charCodeAt(i + 1) & 0xff) << 8;
+  case 3: h ^= (str.charCodeAt(i + 2) & 0xff) << 16; break;
+  case 2: h ^= (str.charCodeAt(i + 1) & 0xff) << 8; break;
   case 1: h ^= (str.charCodeAt(i) & 0xff);
           h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));
   }

--- a/murmurhash3_gc.js
+++ b/murmurhash3_gc.js
@@ -1,34 +1,34 @@
 /**
  * JS Implementation of MurmurHash3 (r136) (as of May 20, 2011)
- * 
+ *
  * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
  * @see http://github.com/garycourt/murmurhash-js
  * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
  * @see http://sites.google.com/site/murmurhash/
- * 
+ *
  * @param {string} key ASCII only
  * @param {number} seed Positive integer only
- * @return {number} 32-bit positive integer hash 
+ * @return {number} 32-bit positive integer hash
  */
 
 function murmurhash3_32_gc(key, seed) {
 	var remainder, bytes, h1, h1b, c1, c1b, c2, c2b, k1, i;
-	
+
 	remainder = key.length & 3; // key.length % 4
 	bytes = key.length - remainder;
 	h1 = seed;
 	c1 = 0xcc9e2d51;
 	c2 = 0x1b873593;
 	i = 0;
-	
+
 	while (i < bytes) {
-	  	k1 = 
+	  	k1 =
 	  	  ((key.charCodeAt(i) & 0xff)) |
 	  	  ((key.charCodeAt(++i) & 0xff) << 8) |
 	  	  ((key.charCodeAt(++i) & 0xff) << 16) |
 	  	  ((key.charCodeAt(++i) & 0xff) << 24);
 		++i;
-		
+
 		k1 = ((((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16))) & 0xffffffff;
 		k1 = (k1 << 15) | (k1 >>> 17);
 		k1 = ((((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16))) & 0xffffffff;
@@ -38,20 +38,20 @@ function murmurhash3_32_gc(key, seed) {
 		h1b = ((((h1 & 0xffff) * 5) + ((((h1 >>> 16) * 5) & 0xffff) << 16))) & 0xffffffff;
 		h1 = (((h1b & 0xffff) + 0x6b64) + ((((h1b >>> 16) + 0xe654) & 0xffff) << 16));
 	}
-	
+
 	k1 = 0;
-	
+
 	switch (remainder) {
-		case 3: k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
-		case 2: k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
+		case 3: k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16; break;
+		case 2: k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8; break;
 		case 1: k1 ^= (key.charCodeAt(i) & 0xff);
-		
+
 		k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16)) & 0xffffffff;
 		k1 = (k1 << 15) | (k1 >>> 17);
 		k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16)) & 0xffffffff;
 		h1 ^= k1;
 	}
-	
+
 	h1 ^= key.length;
 
 	h1 ^= h1 >>> 16;


### PR DESCRIPTION
This pull request adds case `break`s where linters expect them. 
