### PR TITLE
updated murmerhash3_32_gc to slightly faster (15%) GTP-4 version

### DIFF
--- a/murmurhash3_gc.js
+++ b/murmurhash3_gc.js
@@ -1,3 +1,5 @@
+// thanks to GPT4 for this updated version which is about 15% faster, probably due to use of Math.imul
+
 /**
  * JS Implementation of MurmurHash3 (r136) (as of May 20, 2011)
  * 
@@ -11,53 +13,49 @@
  * @return {number} 32-bit positive integer hash 
  */
 
-function murmurhash3_32_gc(key, seed) {
-	var remainder, bytes, h1, h1b, c1, c1b, c2, c2b, k1, i;
-	
-	remainder = key.length & 3; // key.length % 4
-	bytes = key.length - remainder;
-	h1 = seed;
-	c1 = 0xcc9e2d51;
-	c2 = 0x1b873593;
-	i = 0;
-	
-	while (i < bytes) {
-	  	k1 = 
-	  	  ((key.charCodeAt(i) & 0xff)) |
-	  	  ((key.charCodeAt(++i) & 0xff) << 8) |
-	  	  ((key.charCodeAt(++i) & 0xff) << 16) |
-	  	  ((key.charCodeAt(++i) & 0xff) << 24);
-		++i;
-		
-		k1 = ((((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16))) & 0xffffffff;
+function murmurhash3_32_gc(key, seed = 0) {
+	const c1 = 0xcc9e2d51;
+	const c2 = 0x1b873593;
+	let h1 = seed;
+	let roundedEnd = key.length & ~0x3;
+
+	for (let i = 0; i < roundedEnd; i += 4) {
+		let k1 =
+		(key.charCodeAt(i) & 0xff) |
+		((key.charCodeAt(i + 1) & 0xff) << 8) |
+		((key.charCodeAt(i + 2) & 0xff) << 16) |
+		((key.charCodeAt(i + 3) & 0xff) << 24);
+		k1 = Math.imul(k1, c1);
 		k1 = (k1 << 15) | (k1 >>> 17);
-		k1 = ((((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16))) & 0xffffffff;
+		k1 = Math.imul(k1, c2);
 
 		h1 ^= k1;
-        h1 = (h1 << 13) | (h1 >>> 19);
-		h1b = ((((h1 & 0xffff) * 5) + ((((h1 >>> 16) * 5) & 0xffff) << 16))) & 0xffffffff;
-		h1 = (((h1b & 0xffff) + 0x6b64) + ((((h1b >>> 16) + 0xe654) & 0xffff) << 16));
+		h1 = (h1 << 13) | (h1 >>> 19);
+		h1 = Math.imul(h1, 5) + 0xe6546b64;
 	}
-	
-	k1 = 0;
-	
-	switch (remainder) {
-		case 3: k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
-		case 2: k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
-		case 1: k1 ^= (key.charCodeAt(i) & 0xff);
-		
-		k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16)) & 0xffffffff;
+
+	let k1 = 0;
+	const val = key.length & 0x3;
+
+	if (val === 3) {
+		k1 = (key.charCodeAt(roundedEnd + 2) & 0xff) << 16;
+	}
+	if (val >= 2) {
+		k1 |= (key.charCodeAt(roundedEnd + 1) & 0xff) << 8;
+	}
+	if (val >= 1) {
+		k1 |= key.charCodeAt(roundedEnd) & 0xff;
+		k1 = Math.imul(k1, c1);
 		k1 = (k1 << 15) | (k1 >>> 17);
-		k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16)) & 0xffffffff;
+		k1 = Math.imul(k1, c2);
 		h1 ^= k1;
 	}
-	
+
 	h1 ^= key.length;
-
 	h1 ^= h1 >>> 16;
-	h1 = (((h1 & 0xffff) * 0x85ebca6b) + ((((h1 >>> 16) * 0x85ebca6b) & 0xffff) << 16)) & 0xffffffff;
+	h1 = Math.imul(h1, 0x85ebca6b);
 	h1 ^= h1 >>> 13;
-	h1 = ((((h1 & 0xffff) * 0xc2b2ae35) + ((((h1 >>> 16) * 0xc2b2ae35) & 0xffff) << 16))) & 0xffffffff;
+	h1 = Math.imul(h1, 0xc2b2ae35);
 	h1 ^= h1 >>> 16;
 
 	return h1 >>> 0;


### PR DESCRIPTION
GPT-4 created a version of this when I asked for a hash routine.  I investigated and found it was based on Gary's version.  I've tested the results and performance, and GPT-4's version produces the same results and is about 15% faster.  This is most likely due to the use of Math.imul in GPT-4's version.